### PR TITLE
Removed Python versions that Pythonista does not support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - "2.6"
+#  - "2.6"  # Pythonista never supported Python 2.6
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
+#  - "3.2"  # Pythonista never supported Python 3.2
+#  - "3.3"  # Pythonista never supported Python 3.3
+#  - "3.4"  # Pythonista never supported Python 3.4
   - "3.5"
   - "3.5-dev" # 3.5 development branch
   - "nightly" # currently points to 3.6-dev


### PR DESCRIPTION
For Travis to test your Pythonista scripts, you would need to make mock versions of Pythonista modules like: appex, dialogs, objc_util, ui, etc.
